### PR TITLE
OTL-1333 Fix the splunk otel collector operator build after dependabot updgraded controller-gen to v0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ QUAY_USER ?= signalfx
 IMG_PREFIX ?= quay.io/${QUAY_USER}
 IMG_REPO ?= splunk-otel-operator
 IMG ?= ${IMG_PREFIX}/${IMG_REPO}:$(addprefix v,${VERSION})
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+# Produce CRDs that work back to Kubernetes v1.16 (no version conversion)
+CRD_OPTIONS ?= crd
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/bundle/manifests/o11y.splunk.com_splunkotelagents.yaml
+++ b/bundle/manifests/o11y.splunk.com_splunkotelagents.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: splunk-otel-operator-system/splunk-otel-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: splunkotelagents.o11y.splunk.com
 spec:
@@ -60,9 +60,13 @@ spec:
                       Collector binary
                     type: object
                   config:
-                    description: Config is the raw JSON to be used as the collector's
+                    description: Config is the raw YAML to be used as the collector's
                       configuration. Refer to the OpenTelemetry Collector documentation
-                      for details.
+                      for details. This will be automatically set by the operator
+                      but can be overriden by the user. No effort is made to merge
+                      the user provided config with the default config set by the
+                      operator. User provided config always overrides the default
+                      config.
                     type: string
                   disabled:
                     description: Disabled determines whether this spec will be depoyed
@@ -71,7 +75,8 @@ spec:
                   env:
                     description: ENV vars to set on the OpenTelemetry Collector's
                       Pods. These can then in certain cases be consumed in the config
-                      file for the Collector.
+                      file for the Collector. Setting this field will override any
+                      existing environment variables set by the operator.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -260,7 +265,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
-                      OpenTelemetry Collector
+                      OpenTelemetry Collector Only applicable in Gateway mode.
                     format: int32
                     type: integer
                   resources:
@@ -2085,9 +2090,13 @@ spec:
                       Collector binary
                     type: object
                   config:
-                    description: Config is the raw JSON to be used as the collector's
+                    description: Config is the raw YAML to be used as the collector's
                       configuration. Refer to the OpenTelemetry Collector documentation
-                      for details.
+                      for details. This will be automatically set by the operator
+                      but can be overriden by the user. No effort is made to merge
+                      the user provided config with the default config set by the
+                      operator. User provided config always overrides the default
+                      config.
                     type: string
                   disabled:
                     description: Disabled determines whether this spec will be depoyed
@@ -2096,7 +2105,8 @@ spec:
                   env:
                     description: ENV vars to set on the OpenTelemetry Collector's
                       Pods. These can then in certain cases be consumed in the config
-                      file for the Collector.
+                      file for the Collector. Setting this field will override any
+                      existing environment variables set by the operator.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -2285,7 +2295,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
-                      OpenTelemetry Collector
+                      OpenTelemetry Collector Only applicable in Gateway mode.
                     format: int32
                     type: integer
                   resources:
@@ -4106,9 +4116,13 @@ spec:
                       Collector binary
                     type: object
                   config:
-                    description: Config is the raw JSON to be used as the collector's
+                    description: Config is the raw YAML to be used as the collector's
                       configuration. Refer to the OpenTelemetry Collector documentation
-                      for details.
+                      for details. This will be automatically set by the operator
+                      but can be overriden by the user. No effort is made to merge
+                      the user provided config with the default config set by the
+                      operator. User provided config always overrides the default
+                      config.
                     type: string
                   disabled:
                     description: Disabled determines whether this spec will be depoyed
@@ -4117,7 +4131,8 @@ spec:
                   env:
                     description: ENV vars to set on the OpenTelemetry Collector's
                       Pods. These can then in certain cases be consumed in the config
-                      file for the Collector.
+                      file for the Collector. Setting this field will override any
+                      existing environment variables set by the operator.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -4306,7 +4321,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
-                      OpenTelemetry Collector
+                      OpenTelemetry Collector Only applicable in Gateway mode.
                     format: int32
                     type: integer
                   resources:

--- a/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
@@ -35,8 +35,11 @@ spec:
           binary
         displayName: Args
         path: agent.args
-      - description: Config is the raw JSON to be used as the collector's configuration.
-          Refer to the OpenTelemetry Collector documentation for details.
+      - description: Config is the raw YAML to be used as the collector's configuration.
+          Refer to the OpenTelemetry Collector documentation for details. This will
+          be automatically set by the operator but can be overriden by the user. No
+          effort is made to merge the user provided config with the default config
+          set by the operator. User provided config always overrides the default config.
         displayName: Config
         path: agent.config
       - description: Disabled determines whether this spec will be depoyed or not.
@@ -44,6 +47,8 @@ spec:
         path: agent.disabled
       - description: ENV vars to set on the OpenTelemetry Collector's Pods. These
           can then in certain cases be consumed in the config file for the Collector.
+          Setting this field will override any existing environment variables set
+          by the operator.
         displayName: Env
         path: agent.env
       - description: HostNetwork indicates if the pod should run in the host networking
@@ -65,7 +70,7 @@ spec:
         displayName: Ports
         path: agent.ports
       - description: Replicas is the number of pod instances for the underlying OpenTelemetry
-          Collector
+          Collector Only applicable in Gateway mode.
         displayName: Replicas
         path: agent.replicas
       - description: Resources to set on the OpenTelemetry Collector pods.
@@ -102,8 +107,11 @@ spec:
           binary
         displayName: Args
         path: clusterReceiver.args
-      - description: Config is the raw JSON to be used as the collector's configuration.
-          Refer to the OpenTelemetry Collector documentation for details.
+      - description: Config is the raw YAML to be used as the collector's configuration.
+          Refer to the OpenTelemetry Collector documentation for details. This will
+          be automatically set by the operator but can be overriden by the user. No
+          effort is made to merge the user provided config with the default config
+          set by the operator. User provided config always overrides the default config.
         displayName: Config
         path: clusterReceiver.config
       - description: Disabled determines whether this spec will be depoyed or not.
@@ -111,6 +119,8 @@ spec:
         path: clusterReceiver.disabled
       - description: ENV vars to set on the OpenTelemetry Collector's Pods. These
           can then in certain cases be consumed in the config file for the Collector.
+          Setting this field will override any existing environment variables set
+          by the operator.
         displayName: Env
         path: clusterReceiver.env
       - description: HostNetwork indicates if the pod should run in the host networking
@@ -132,7 +142,7 @@ spec:
         displayName: Ports
         path: clusterReceiver.ports
       - description: Replicas is the number of pod instances for the underlying OpenTelemetry
-          Collector
+          Collector Only applicable in Gateway mode.
         displayName: Replicas
         path: clusterReceiver.replicas
       - description: Resources to set on the OpenTelemetry Collector pods.
@@ -165,8 +175,11 @@ spec:
           binary
         displayName: Args
         path: gateway.args
-      - description: Config is the raw JSON to be used as the collector's configuration.
-          Refer to the OpenTelemetry Collector documentation for details.
+      - description: Config is the raw YAML to be used as the collector's configuration.
+          Refer to the OpenTelemetry Collector documentation for details. This will
+          be automatically set by the operator but can be overriden by the user. No
+          effort is made to merge the user provided config with the default config
+          set by the operator. User provided config always overrides the default config.
         displayName: Config
         path: gateway.config
       - description: Disabled determines whether this spec will be depoyed or not.
@@ -174,6 +187,8 @@ spec:
         path: gateway.disabled
       - description: ENV vars to set on the OpenTelemetry Collector's Pods. These
           can then in certain cases be consumed in the config file for the Collector.
+          Setting this field will override any existing environment variables set
+          by the operator.
         displayName: Env
         path: gateway.env
       - description: HostNetwork indicates if the pod should run in the host networking
@@ -195,7 +210,7 @@ spec:
         displayName: Ports
         path: gateway.ports
       - description: Replicas is the number of pod instances for the underlying OpenTelemetry
-          Collector
+          Collector Only applicable in Gateway mode.
         displayName: Replicas
         path: gateway.replicas
       - description: Resources to set on the OpenTelemetry Collector pods.

--- a/config/crd/bases/o11y.splunk.com_splunkotelagents.yaml
+++ b/config/crd/bases/o11y.splunk.com_splunkotelagents.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: splunkotelagents.o11y.splunk.com
 spec:
@@ -51,9 +51,13 @@ spec:
                       Collector binary
                     type: object
                   config:
-                    description: Config is the raw JSON to be used as the collector's
+                    description: Config is the raw YAML to be used as the collector's
                       configuration. Refer to the OpenTelemetry Collector documentation
-                      for details.
+                      for details. This will be automatically set by the operator
+                      but can be overriden by the user. No effort is made to merge
+                      the user provided config with the default config set by the
+                      operator. User provided config always overrides the default
+                      config.
                     type: string
                   disabled:
                     description: Disabled determines whether this spec will be depoyed
@@ -62,7 +66,8 @@ spec:
                   env:
                     description: ENV vars to set on the OpenTelemetry Collector's
                       Pods. These can then in certain cases be consumed in the config
-                      file for the Collector.
+                      file for the Collector. Setting this field will override any
+                      existing environment variables set by the operator.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -251,7 +256,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
-                      OpenTelemetry Collector
+                      OpenTelemetry Collector Only applicable in Gateway mode.
                     format: int32
                     type: integer
                   resources:
@@ -2076,9 +2081,13 @@ spec:
                       Collector binary
                     type: object
                   config:
-                    description: Config is the raw JSON to be used as the collector's
+                    description: Config is the raw YAML to be used as the collector's
                       configuration. Refer to the OpenTelemetry Collector documentation
-                      for details.
+                      for details. This will be automatically set by the operator
+                      but can be overriden by the user. No effort is made to merge
+                      the user provided config with the default config set by the
+                      operator. User provided config always overrides the default
+                      config.
                     type: string
                   disabled:
                     description: Disabled determines whether this spec will be depoyed
@@ -2087,7 +2096,8 @@ spec:
                   env:
                     description: ENV vars to set on the OpenTelemetry Collector's
                       Pods. These can then in certain cases be consumed in the config
-                      file for the Collector.
+                      file for the Collector. Setting this field will override any
+                      existing environment variables set by the operator.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -2276,7 +2286,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
-                      OpenTelemetry Collector
+                      OpenTelemetry Collector Only applicable in Gateway mode.
                     format: int32
                     type: integer
                   resources:
@@ -4097,9 +4107,13 @@ spec:
                       Collector binary
                     type: object
                   config:
-                    description: Config is the raw JSON to be used as the collector's
+                    description: Config is the raw YAML to be used as the collector's
                       configuration. Refer to the OpenTelemetry Collector documentation
-                      for details.
+                      for details. This will be automatically set by the operator
+                      but can be overriden by the user. No effort is made to merge
+                      the user provided config with the default config set by the
+                      operator. User provided config always overrides the default
+                      config.
                     type: string
                   disabled:
                     description: Disabled determines whether this spec will be depoyed
@@ -4108,7 +4122,8 @@ spec:
                   env:
                     description: ENV vars to set on the OpenTelemetry Collector's
                       Pods. These can then in certain cases be consumed in the config
-                      file for the Collector.
+                      file for the Collector. Setting this field will override any
+                      existing environment variables set by the operator.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -4297,7 +4312,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
-                      OpenTelemetry Collector
+                      OpenTelemetry Collector Only applicable in Gateway mode.
                     format: int32
                     type: integer
                   resources:

--- a/config/manifests/bases/splunk-otel-collector-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/splunk-otel-collector-operator.clusterserviceversion.yaml
@@ -23,8 +23,11 @@ spec:
           binary
         displayName: Args
         path: agent.args
-      - description: Config is the raw JSON to be used as the collector's configuration.
-          Refer to the OpenTelemetry Collector documentation for details.
+      - description: Config is the raw YAML to be used as the collector's configuration.
+          Refer to the OpenTelemetry Collector documentation for details. This will
+          be automatically set by the operator but can be overriden by the user. No
+          effort is made to merge the user provided config with the default config
+          set by the operator. User provided config always overrides the default config.
         displayName: Config
         path: agent.config
       - description: Disabled determines whether this spec will be depoyed or not.
@@ -32,6 +35,8 @@ spec:
         path: agent.disabled
       - description: ENV vars to set on the OpenTelemetry Collector's Pods. These
           can then in certain cases be consumed in the config file for the Collector.
+          Setting this field will override any existing environment variables set
+          by the operator.
         displayName: Env
         path: agent.env
       - description: HostNetwork indicates if the pod should run in the host networking
@@ -53,7 +58,7 @@ spec:
         displayName: Ports
         path: agent.ports
       - description: Replicas is the number of pod instances for the underlying OpenTelemetry
-          Collector
+          Collector Only applicable in Gateway mode.
         displayName: Replicas
         path: agent.replicas
       - description: Resources to set on the OpenTelemetry Collector pods.
@@ -90,8 +95,11 @@ spec:
           binary
         displayName: Args
         path: clusterReceiver.args
-      - description: Config is the raw JSON to be used as the collector's configuration.
-          Refer to the OpenTelemetry Collector documentation for details.
+      - description: Config is the raw YAML to be used as the collector's configuration.
+          Refer to the OpenTelemetry Collector documentation for details. This will
+          be automatically set by the operator but can be overriden by the user. No
+          effort is made to merge the user provided config with the default config
+          set by the operator. User provided config always overrides the default config.
         displayName: Config
         path: clusterReceiver.config
       - description: Disabled determines whether this spec will be depoyed or not.
@@ -99,6 +107,8 @@ spec:
         path: clusterReceiver.disabled
       - description: ENV vars to set on the OpenTelemetry Collector's Pods. These
           can then in certain cases be consumed in the config file for the Collector.
+          Setting this field will override any existing environment variables set
+          by the operator.
         displayName: Env
         path: clusterReceiver.env
       - description: HostNetwork indicates if the pod should run in the host networking
@@ -120,7 +130,7 @@ spec:
         displayName: Ports
         path: clusterReceiver.ports
       - description: Replicas is the number of pod instances for the underlying OpenTelemetry
-          Collector
+          Collector Only applicable in Gateway mode.
         displayName: Replicas
         path: clusterReceiver.replicas
       - description: Resources to set on the OpenTelemetry Collector pods.
@@ -153,8 +163,11 @@ spec:
           binary
         displayName: Args
         path: gateway.args
-      - description: Config is the raw JSON to be used as the collector's configuration.
-          Refer to the OpenTelemetry Collector documentation for details.
+      - description: Config is the raw YAML to be used as the collector's configuration.
+          Refer to the OpenTelemetry Collector documentation for details. This will
+          be automatically set by the operator but can be overriden by the user. No
+          effort is made to merge the user provided config with the default config
+          set by the operator. User provided config always overrides the default config.
         displayName: Config
         path: gateway.config
       - description: Disabled determines whether this spec will be depoyed or not.
@@ -162,6 +175,8 @@ spec:
         path: gateway.disabled
       - description: ENV vars to set on the OpenTelemetry Collector's Pods. These
           can then in certain cases be consumed in the config file for the Collector.
+          Setting this field will override any existing environment variables set
+          by the operator.
         displayName: Env
         path: gateway.env
       - description: HostNetwork indicates if the pod should run in the host networking
@@ -183,7 +198,7 @@ spec:
         displayName: Ports
         path: gateway.ports
       - description: Replicas is the number of pod instances for the underlying OpenTelemetry
-          Collector
+          Collector Only applicable in Gateway mode.
         displayName: Replicas
         path: gateway.replicas
       - description: Resources to set on the OpenTelemetry Collector pods.


### PR DESCRIPTION
The dependabot upgraded a dependency in the splunk-otel-collector-operator project that broke the build. This controller-gen dependency upgrade caused crds of version v1beta1 to be deprecated. 

You can see more info about this here: https://book.kubebuilder.io/reference/generating-crd.html