### PR TITLE
Auto configure pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager -ldflags ${LD_FLAGS} main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go -ldflags ${LD_FLAGS}
+	go run -ldflags=${LD_FLAGS} ./main.go
 
 docker-build: ## Build docker image with the manager.
 	docker build --build-arg VERSION_DATE=${VERSION_DATE} --build-arg VERSION_PKG=${VERSION_PKG} --build-arg VERSION_COLLECTOR=${VERSION_COLLECTOR} --build-arg VERSION=${VERSION} -t ${IMG} .

--- a/PROJECT
+++ b/PROJECT
@@ -2,10 +2,10 @@ domain: splunk.com
 layout:
 - go.kubebuilder.io/v3
 multigroup: true
-projectName: splunk-otel-collector-operator
-repo: github.com/signalfx/splunk-otel-collector-operator
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
+projectName: splunk-otel-collector-operator
+repo: github.com/signalfx/splunk-otel-collector-operator
 resources:
 - api:
     crdVersion: v1

--- a/apis/o11y/v1alpha1/splunkotelagent_webhook.go
+++ b/apis/o11y/v1alpha1/splunkotelagent_webhook.go
@@ -41,7 +41,7 @@ func (r *SplunkOtelAgent) SetupWebhookWithManager(mgr ctrl.Manager, distro autod
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-o11y-splunk-com-v1alpha1-splunkotelagent,mutating=true,failurePolicy=fail,sideEffects=None,groups=o11y.splunk.com,resources=splunkotelagents,verbs=create;update,versions=v1alpha1,name=msplunkotelagent.kb.io,admissionReviewVersions={v1}
+//+kubebuilder:webhook:path=/mutate-o11y-splunk-com-v1alpha1-splunkotelagent,mutating=true,failurePolicy=fail,sideEffects=None,groups=o11y.splunk.com,resources=splunkotelagents,verbs=create;update,versions=v1alpha1,name=msplunkotelagent.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &SplunkOtelAgent{}
 
@@ -62,7 +62,7 @@ func (r *SplunkOtelAgent) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-o11y-splunk-com-v1alpha1-splunkotelagent,mutating=false,failurePolicy=fail,sideEffects=None,groups=o11y.splunk.com,resources=splunkotelagents,verbs=create;update,versions=v1alpha1,name=vsplunkotelagent.kb.io,admissionReviewVersions={v1}
+//+kubebuilder:webhook:path=/validate-o11y-splunk-com-v1alpha1-splunkotelagent,mutating=false,failurePolicy=fail,sideEffects=None,groups=o11y.splunk.com,resources=splunkotelagents,verbs=create;update,versions=v1alpha1,name=vsplunkotelagent.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &SplunkOtelAgent{}
 

--- a/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
@@ -322,6 +322,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - o11y.splunk.com
           resources:
           - splunkotelagents
@@ -493,6 +501,28 @@ spec:
     webhookPath: /convert
   - admissionReviewVersions:
     - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: splunk-otel-operator-controller-manager
+    failurePolicy: Ignore
+    generateName: mpod.kb.io
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-v1-pod
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
     containerPort: 443
     deploymentName: splunk-otel-operator-controller-manager
     failurePolicy: Fail
@@ -513,6 +543,7 @@ spec:
     webhookPath: /mutate-o11y-splunk-com-v1alpha1-splunkotelagent
   - admissionReviewVersions:
     - v1
+    - v1beta1
     containerPort: 443
     deploymentName: splunk-otel-operator-controller-manager
     failurePolicy: Fail

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,6 +79,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - o11y.splunk.com
   resources:
   - splunkotelagents

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -8,6 +8,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -26,6 +27,27 @@ webhooks:
     resources:
     - splunkotelagents
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-pod
+  failurePolicy: Ignore
+  name: mpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -36,6 +58,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/golangci/golangci-lint v1.42.1
 	github.com/stretchr/testify v1.7.0
+	go.opentelemetry.io/otel v0.20.0
 	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -878,6 +878,7 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUzl5H4LY0Kc=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0/go.mod h1:oVGt1LRbBOBq1A5BQLlUg9UaU/54aiHw8cgjV3aWZ/E=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:2AboqHi0CiIZU0qwhtUfCYD1GeUzvvIXWNkhDt7ZMG4=
+go.opentelemetry.io/otel v0.20.0 h1:eaP0Fqu7SXHwvjiqDq83zImeehOHX8doTvU9AwXON8g=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
 go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=

--- a/internal/webhooks/handler.go
+++ b/internal/webhooks/handler.go
@@ -1,0 +1,213 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/signalfx/splunk-otel-collector-operator/apis/o11y/v1alpha1"
+)
+
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,sideEffects=none,admissionReviewVersions={v1,v1beta1}
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch
+// +kubebuilder:rbac:groups=o11y.splunk.com,resources=splunkotelagents,verbs=get;list;watch
+// +kubebuilder:rbac:groups="apps",resources=replicasets,verbs=get;list;watch
+
+const (
+	operatorNamespace           = "splunk-otel-operator-system"
+	envSplunkOtelAgent          = "SPLUNK_OTEL_AGENT"
+	envOTELServiceName          = "OTEL_SERVICE_NAME"
+	envOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	envOTELTracesExporter       = "OTEL_TRACES_EXPORTER"
+	envOTELResourceAttrs        = "OTEL_RESOURCE_ATTRIBUTES"
+
+	exporterOTLP   = "otlp"
+	exporterJaeger = "jaeger-thrift-splunk"
+
+	annotationConfInjectionEnabled = "o11y.splunk.com/inject-config"
+	annotationStatus               = "o11y.splunk.com/injection-status"
+	annotationReason               = "o11y.splunk.com/injection-reason"
+)
+
+type handler struct {
+	client  client.Client
+	logger  logr.Logger
+	decoder *admission.Decoder
+}
+
+type config struct {
+	exporter string
+	endpoint string
+}
+
+// NewHandler creates a new WebhookHandler.
+func NewHandler(logger logr.Logger, cl client.Client) admission.Handler {
+	return &handler{
+		client: cl,
+		logger: logger,
+	}
+}
+
+func (h *handler) patch(req admission.Request, pod corev1.Pod, err error) admission.Response {
+	if err != nil {
+		pod.Annotations[annotationStatus] = "error"
+		pod.Annotations[annotationReason] = err.Error()
+	}
+
+	marshaledPod, err := json.Marshal(pod)
+	if err != nil {
+		h.logger.Error(err, "unable to marshal pod", "pod", pod.Name)
+		return admission.Allowed("")
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+
+}
+
+func (h *handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	pod := corev1.Pod{}
+	err := h.decoder.Decode(req, &pod)
+	if err != nil {
+		h.logger.Error(err, "unable to decode pod")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+
+	if !strings.EqualFold(pod.Annotations[annotationConfInjectionEnabled], "true") {
+		return admission.Allowed("")
+	}
+
+	// we use the req.Namespace here because the pod might have not been created yet
+	ns := corev1.Namespace{}
+	err = h.client.Get(ctx, types.NamespacedName{Name: req.Namespace, Namespace: ""}, &ns)
+	if err != nil {
+		h.logger.Error(err, "unable to get pod namespace", "namespace", req.Namespace)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	spec, err := h.getAgentSpec(ctx)
+	if err != nil {
+		msg := "unable to get splunk agent spec. make sure SpluknOtelAgent is deployed"
+		h.logger.Error(err, msg)
+		return h.patch(req, pod, errors.New(msg))
+	}
+
+	cfg := configFromSpec(spec)
+
+	pod = h.injectConfigIntoPod(ctx, cfg, pod, ns)
+	return h.patch(req, pod, nil)
+}
+
+func configFromSpec(spec *v1alpha1.SplunkOtelAgentSpec) config {
+
+	cfg := config{
+		exporter: exporterOTLP,
+		endpoint: "http://$(SPLUNK_OTEL_AGENT):4317",
+	}
+
+	if spec.Agent.Disabled {
+		if !spec.Gateway.Disabled {
+			cfg.endpoint = fmt.Sprintf("http://splunk-otel-collector.%s:4317", operatorNamespace)
+		} else {
+			cfg.exporter = exporterJaeger
+			cfg.endpoint = fmt.Sprintf("https://ingest.%s.signalfx.com/v2/trace", spec.Realm)
+		}
+	}
+
+	return cfg
+}
+
+func (h *handler) injectConfigIntoPod(ctx context.Context, cfg config, pod corev1.Pod, ns corev1.Namespace) corev1.Pod {
+	if len(pod.Spec.Containers) < 1 {
+		h.logger.Info("no containers found in pod", "pod", pod.Name)
+		return pod
+	}
+
+	container := &pod.Spec.Containers[0]
+	resourceAttrs, resourceEnvIdx := h.createResourceMap(ctx, ns, pod)
+	// TODO: some attrs such as node name, pod uid could be empty at this stage
+	// so we should use k8s downward API to get read them lazily
+
+	newEnv := []corev1.EnvVar{
+		{Name: envSplunkOtelAgent, ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "status.hostIP",
+			},
+		}},
+		{Name: envOTELServiceName, Value: serviceName(pod, resourceAttrs)},
+		{Name: envOTELExporterOTLPEndpoint, Value: cfg.endpoint},
+		{Name: envOTELTracesExporter, Value: cfg.exporter},
+		// TODO: add SPLUNK_ACCESS_TOKEN using env from
+		// 1. check if "splunk-access-token" secret key is present in
+		// the same namespace as the pod and use ValueFrom to inject it.
+		// 2. if it is not present, read it from the operator namespace
+		// and inject as an environment variable?
+	}
+
+	resourceEnv := corev1.EnvVar{Name: envOTELResourceAttrs, Value: resourceMapToStr(resourceAttrs)}
+	if resourceEnvIdx > -1 {
+		container.Env[resourceEnvIdx] = resourceEnv
+	} else {
+		newEnv = append(newEnv, resourceEnv)
+	}
+
+	container.Env = h.injectEnvVars(container.Env, newEnv)
+
+	return pod
+}
+
+func (h *handler) injectEnvVars(old []corev1.EnvVar, new []corev1.EnvVar) []corev1.EnvVar {
+	contains := func(s []corev1.EnvVar, e corev1.EnvVar) bool {
+		for _, a := range s {
+			if e == a {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, ne := range new {
+		if !contains(old, ne) {
+			old = append(old, ne)
+		}
+	}
+	return old
+}
+
+// podAnnotator implements admission.DecoderInjector.
+// A decoder will be automatically injected.
+
+// InjectDecoder injects the decoder.
+func (h *handler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *handler) getAgentSpec(ctx context.Context) (*v1alpha1.SplunkOtelAgentSpec, error) {
+	specs := &v1alpha1.SplunkOtelAgentList{}
+	err := h.client.List(ctx, specs)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(specs.Items) {
+	case 0:
+		return nil, fmt.Errorf("SplunkOtelAgent is not deployed yet")
+	case 1:
+		return &specs.Items[0].Spec, nil
+	default:
+		return nil, fmt.Errorf("found more than one SplunkOtelAgent")
+	}
+}

--- a/internal/webhooks/handler_test.go
+++ b/internal/webhooks/handler_test.go
@@ -1,0 +1,138 @@
+// Copyright Splunk Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/signalfx/splunk-otel-collector-operator/apis/o11y/v1alpha1"
+)
+
+func TestConfigFromSpec(t *testing.T) {
+	cases := []struct {
+		spec *v1alpha1.SplunkOtelAgentSpec
+		cfg  config
+	}{
+		{
+			spec: &v1alpha1.SplunkOtelAgentSpec{
+				Agent: v1alpha1.SplunkCollectorSpec{},
+			},
+			cfg: config{
+				exporter: "otlp",
+				endpoint: "http://$(SPLUNK_OTEL_AGENT):4317",
+			},
+		},
+		{
+			spec: &v1alpha1.SplunkOtelAgentSpec{
+				Agent: v1alpha1.SplunkCollectorSpec{Disabled: true},
+			},
+			cfg: config{
+				exporter: "otlp",
+				endpoint: "http://splunk-otel-collector.splunk-otel-operator-system:4317",
+			},
+		},
+		{
+			spec: &v1alpha1.SplunkOtelAgentSpec{
+				Agent:   v1alpha1.SplunkCollectorSpec{Disabled: true},
+				Gateway: v1alpha1.SplunkCollectorSpec{Disabled: true},
+				Realm:   "mars0",
+			},
+			cfg: config{
+				exporter: "jaeger-thrift-splunk",
+				endpoint: "https://ingest.mars0.signalfx.com/v2/trace",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		got := configFromSpec(tc.spec)
+		assert.Equal(t, tc.cfg, got)
+	}
+}
+
+func TestInjectConfig(t *testing.T) {
+	cases := []struct {
+		cfg          config
+		container    *corev1.Container
+		shouldInject bool
+	}{
+		{
+			cfg:          config{},
+			container:    nil,
+			shouldInject: false,
+		},
+		{
+			cfg: config{
+				exporter: "otlp",
+				endpoint: "localhost",
+			},
+			container: &corev1.Container{
+				Name: "test",
+			},
+			shouldInject: true,
+		},
+		{
+			cfg: config{
+				exporter: "some-exporter",
+				endpoint: "http://splunk",
+			},
+			container: &corev1.Container{
+				Name: "test",
+			},
+			shouldInject: true,
+		},
+	}
+
+	h := &handler{
+		logger: logr.DiscardLogger{},
+	}
+
+	for _, tc := range cases {
+		ns := corev1.Namespace{
+			Spec: corev1.NamespaceSpec{},
+		}
+
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod",
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{}},
+		}
+		if tc.container != nil {
+			pod.Spec.Containers = append(pod.Spec.Containers, *tc.container)
+		}
+		got := h.injectConfigIntoPod(context.Background(), tc.cfg, pod, ns)
+
+		if !tc.shouldInject {
+			continue
+		}
+
+		gc := got.Spec.Containers[0]
+		assert.Contains(t, gc.Env, corev1.EnvVar{Name: "OTEL_SERVICE_NAME", Value: "test-pod"})
+		assert.Contains(t, gc.Env, corev1.EnvVar{Name: "OTEL_TRACES_EXPORTER", Value: tc.cfg.exporter})
+		assert.Contains(t, gc.Env, corev1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: tc.cfg.endpoint})
+		assert.Contains(t, gc.Env, corev1.EnvVar{Name: "SPLUNK_OTEL_AGENT", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "status.hostIP",
+			},
+		}})
+	}
+}

--- a/internal/webhooks/resources.go
+++ b/internal/webhooks/resources.go
@@ -1,0 +1,144 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/semconv"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	annotationName = "app.kubernetes.io/name"
+	annotationApp  = "app"
+)
+
+func serviceName(pod corev1.Pod, resources map[string]string) string {
+	if name := pod.Annotations[annotationApp]; name != "" {
+		return name
+	}
+	if name := pod.Annotations[annotationName]; name != "" {
+		return name
+	}
+	if name := resources[string(semconv.K8SDeploymentNameKey)]; name != "" {
+		return name
+	}
+	if name := resources[string(semconv.K8SStatefulSetNameKey)]; name != "" {
+		return name
+	}
+	if name := resources[string(semconv.K8SJobNameKey)]; name != "" {
+		return name
+	}
+	if name := resources[string(semconv.K8SCronJobNameKey)]; name != "" {
+		return name
+	}
+	if name := resources[string(semconv.K8SPodNameKey)]; name != "" {
+		return name
+	}
+	return pod.Spec.Containers[0].Name
+}
+
+// createResourceMap creates resource attribute map.
+// User defined attributes (in explicitly set env var) have higher precedence.
+func (h *handler) createResourceMap(ctx context.Context, ns corev1.Namespace, pod corev1.Pod) (map[string]string, int) {
+
+	k8sResources := map[attribute.Key]string{}
+	k8sResources[semconv.K8SNamespaceNameKey] = ns.Name
+	k8sResources[semconv.K8SContainerNameKey] = pod.Spec.Containers[0].Name
+	// Some fields might be empty - node name, pod name
+	// The pod name might be empty if the pod is created form deployment template
+	k8sResources[semconv.K8SPodNameKey] = pod.Name
+	k8sResources[semconv.K8SPodUIDKey] = string(pod.UID)
+	k8sResources[semconv.K8SNodeNameKey] = pod.Spec.NodeName
+	h.addParentResourceLabels(ctx, ns, pod.ObjectMeta, k8sResources)
+
+	res := map[string]string{}
+	for k, v := range k8sResources {
+		if v != "" {
+			res[string(k)] = v
+		}
+	}
+
+	// get existing resources env var and add them to the map
+	existingResourceEnvIdx := getIndexOfEnv(pod.Spec.Containers[0].Env, envOTELResourceAttrs)
+	if existingResourceEnvIdx > -1 {
+		existingResArr := strings.Split(pod.Spec.Containers[0].Env[existingResourceEnvIdx].Value, ",")
+		for _, kv := range existingResArr {
+			keyValueArr := strings.Split(strings.TrimSpace(kv), "=")
+			if len(keyValueArr) != 2 {
+				h.logger.Info("found invalid resource attribute", "resource", pod.Name, "attribute", kv)
+				continue
+			}
+			res[keyValueArr[0]] = keyValueArr[1]
+		}
+	}
+
+	return res, existingResourceEnvIdx
+}
+
+func (h *handler) addParentResourceLabels(ctx context.Context, ns corev1.Namespace, objectMeta metav1.ObjectMeta, resources map[attribute.Key]string) {
+	for _, owner := range objectMeta.OwnerReferences {
+		switch strings.ToLower(owner.Kind) {
+		case "replicaset":
+			resources[semconv.K8SReplicaSetNameKey] = owner.Name
+			resources[semconv.K8SReplicaSetUIDKey] = string(owner.UID)
+			// parent of ReplicaSet is e.g. Deployment which we are interested to know
+			rs := appsv1.ReplicaSet{}
+			// ignore the error. The object might not exist, the error is not important, getting labels is just the best effort
+			//nolint:errcheck
+			h.client.Get(ctx, types.NamespacedName{
+				Namespace: ns.Name,
+				Name:      owner.Name,
+			}, &rs)
+			h.addParentResourceLabels(ctx, ns, rs.ObjectMeta, resources)
+		case "deployment":
+			resources[semconv.K8SDeploymentNameKey] = owner.Name
+			resources[semconv.K8SDeploymentUIDKey] = string(owner.UID)
+		case "statefulset":
+			resources[semconv.K8SStatefulSetNameKey] = owner.Name
+			resources[semconv.K8SStatefulSetUIDKey] = string(owner.UID)
+		case "daemonset":
+			resources[semconv.K8SDaemonSetNameKey] = owner.Name
+			resources[semconv.K8SDaemonSetUIDKey] = string(owner.UID)
+		case "job":
+			resources[semconv.K8SJobNameKey] = owner.Name
+			resources[semconv.K8SJobUIDKey] = string(owner.UID)
+		case "cronjob":
+			resources[semconv.K8SCronJobNameKey] = owner.Name
+			resources[semconv.K8SCronJobUIDKey] = string(owner.UID)
+		}
+	}
+}
+
+func getIndexOfEnv(envs []corev1.EnvVar, name string) int {
+	for i := range envs {
+		if envs[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func resourceMapToStr(res map[string]string) string {
+	keys := make([]string, 0, len(res))
+	for k := range res {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var str = ""
+	for _, k := range keys {
+		if str != "" {
+			str += ","
+		}
+		str += fmt.Sprintf("%s=%s", k, res[k])
+	}
+
+	return str
+}

--- a/internal/webhooks/resources.go
+++ b/internal/webhooks/resources.go
@@ -126,19 +126,10 @@ func getIndexOfEnv(envs []corev1.EnvVar, name string) int {
 }
 
 func resourceMapToStr(res map[string]string) string {
-	keys := make([]string, 0, len(res))
+	kvPairs := make([]string, 0, len(res))
 	for k := range res {
-		keys = append(keys, k)
+		kvPairs = append(kvPairs, fmt.Sprintf("%s=%s", k, res[k]))
 	}
-	sort.Strings(keys)
-
-	var str = ""
-	for _, k := range keys {
-		if str != "" {
-			str += ","
-		}
-		str += fmt.Sprintf("%s=%s", k, res[k])
-	}
-
-	return str
+	sort.Strings(kvPairs)
+	return strings.Join(kvPairs, ",")
 }

--- a/internal/webhooks/resources_test.go
+++ b/internal/webhooks/resources_test.go
@@ -1,0 +1,100 @@
+// Copyright Splunk Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCreateResourceMap(t *testing.T) {
+	cases := []struct {
+		containerName string
+		podName       string
+		nodeName      string
+		uid           string
+		namespace     string
+		env           []corev1.EnvVar
+		attrs         map[string]string
+		idx           int
+	}{
+		{
+			containerName: "test-container1",
+			namespace:     "test-namespace",
+			podName:       "test-pod",
+			nodeName:      "test-node",
+			uid:           "12345",
+			attrs: map[string]string{
+				"k8s.container.name": "test-container1",
+				"k8s.namespace.name": "test-namespace",
+				"k8s.node.name":      "test-node",
+				"k8s.pod.name":       "test-pod",
+				"k8s.pod.uid":        "12345",
+			},
+			idx: -1,
+		},
+		{
+			containerName: "test-container2",
+			env: []corev1.EnvVar{
+				{
+					Name:  "env2",
+					Value: "value2",
+				},
+				{
+					Name:  envOTELResourceAttrs,
+					Value: "k1=v1,k2=v2,k3=v3=v4",
+				},
+			},
+			attrs: map[string]string{
+				"k1":                 "v1",
+				"k2":                 "v2",
+				"k8s.container.name": "test-container2",
+			},
+			idx: 1,
+		},
+	}
+
+	h := &handler{
+		logger: logr.DiscardLogger{},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			pod := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: c.podName,
+					UID:  types.UID(c.uid),
+				},
+				Spec: corev1.PodSpec{
+					NodeName: c.nodeName,
+					Containers: []corev1.Container{{
+						Name: c.containerName,
+						Env:  c.env,
+					}},
+				},
+			}
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: c.namespace}}
+			attrs, idx := h.createResourceMap(context.Background(), ns, pod)
+			assert.Equal(t, attrs, c.attrs)
+			assert.Equal(t, idx, c.idx)
+		})
+	}
+}

--- a/internal/webhooks/suite_test.go
+++ b/internal/webhooks/suite_test.go
@@ -1,0 +1,145 @@
+// Copyright Splunk Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/signalfx/splunk-otel-collector-operator/apis/o11y/v1alpha1"
+	"github.com/signalfx/splunk-otel-collector-operator/internal/autodetect"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	testScheme *runtime.Scheme = scheme.Scheme
+	ctx        context.Context
+	cancel     context.CancelFunc
+)
+
+func TestMain(m *testing.M) {
+	ctx, cancel = context.WithCancel(context.TODO())
+	defer cancel()
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+		},
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	if err = v1alpha1.AddToScheme(testScheme); err != nil {
+		fmt.Printf("failed to register scheme: %v", err)
+		os.Exit(1)
+	}
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             testScheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	if err != nil {
+		fmt.Printf("failed to start webhook server: %v", err)
+		os.Exit(1)
+	}
+
+	if err = (&v1alpha1.SplunkOtelAgent{}).SetupWebhookWithManager(mgr, autodetect.UnknownDistro); err != nil {
+		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel = context.WithCancel(context.TODO())
+	defer cancel()
+	go func() {
+		if err = mgr.Start(ctx); err != nil {
+			fmt.Printf("failed to start manager: %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	// wait for the webhook server to get ready
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		if err = retry.OnError(wait.Backoff{
+			Steps:    20,
+			Duration: 10 * time.Millisecond,
+			Factor:   1.5,
+			Jitter:   0.1,
+			Cap:      time.Second * 30,
+		}, func(error) bool {
+			return true
+		}, func() error {
+			// #nosec G402
+			conn, dialerErr := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+			if dialerErr != nil {
+				return dialerErr
+			}
+			_ = conn.Close()
+			return nil
+		}); err != nil {
+			fmt.Printf("failed to wait for webhook server to be ready: %v", err)
+			os.Exit(1)
+		}
+	}(wg)
+	wg.Wait()
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		fmt.Printf("failed to stop testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -2,6 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 crdDir: ./tests/_build/crds/
 artifactsDir: ./tests/_build/artifacts/
+kindNodeCache: true
 kindContainers:
   - local/splunk-otel-operator:e2e
 commands:

--- a/main.go
+++ b/main.go
@@ -29,11 +29,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	o11yv1alpha1 "github.com/signalfx/splunk-otel-collector-operator/apis/o11y/v1alpha1"
 	o11ycontrollers "github.com/signalfx/splunk-otel-collector-operator/controllers/o11y"
 	"github.com/signalfx/splunk-otel-collector-operator/internal/autodetect"
 	"github.com/signalfx/splunk-otel-collector-operator/internal/version"
+	"github.com/signalfx/splunk-otel-collector-operator/internal/webhooks"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -104,6 +106,13 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "SplunkOtelAgent")
 		os.Exit(1)
 	}
+
+	mgr.GetWebhookServer().Register("/mutate-v1-pod", &webhook.Admission{
+		Handler: webhooks.NewHandler(
+			ctrl.Log.WithName("webhook-handler"),
+			mgr.GetClient(),
+		),
+	})
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/tests/e2e/config-injection/00-install.yaml
+++ b/tests/e2e/config-injection/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-access-token
+type: Opaque
+stringData:
+  access-token: 0123456789--1234567-12

--- a/tests/e2e/config-injection/01-install.yaml
+++ b/tests/e2e/config-injection/01-install.yaml
@@ -1,0 +1,8 @@
+apiVersion: o11y.splunk.com/v1alpha1
+kind: SplunkOtelAgent
+metadata:
+  name: test-conf-injection
+  namespace: splunk-otel-operator-system
+spec:
+  clusterName: test-cluster
+  realm: my-splunk-realm

--- a/tests/e2e/config-injection/02-install.yaml
+++ b/tests/e2e/config-injection/02-install.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sleep 25

--- a/tests/e2e/config-injection/03-assert.yaml
+++ b/tests/e2e/config-injection/03-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+  namespace: config-injection-test-ns
+  annotations:
+    o11y.splunk.com/inject-config: "true"
+spec:
+  containers:
+  - name: ubuntu
+    command:
+      - /bin/sleep
+      - infinity
+    env:
+      - name: SPLUNK_OTEL_AGENT
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: status.hostIP
+      - name: OTEL_SERVICE_NAME
+        value: ubuntu
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(SPLUNK_OTEL_AGENT):4317
+      - name: OTEL_TRACES_EXPORTER
+        value: otlp
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        value: k8s.container.name=ubuntu,k8s.namespace.name=config-injection-test-ns,k8s.pod.name=ubuntu

--- a/tests/e2e/config-injection/03-install.yaml
+++ b/tests/e2e/config-injection/03-install.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace 
+metadata:
+  name: config-injection-test-ns
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+  namespace: config-injection-test-ns
+  labels:
+    app: ubuntu
+  annotations:
+    o11y.splunk.com/inject-config: "true"
+spec:
+  containers:
+  - name: ubuntu
+    image: ubuntu:latest
+    command: ["/bin/sleep", "infinity"]
+    imagePullPolicy: IfNotPresent
+  restartPolicy: Always


### PR DESCRIPTION
This PR adds a pod mutator that will auto inject Splunk instrumentation config based on how the Splunk Otel agents are deployed into all pods. Pods must opt-in to be auto-configured by `o11y.splunk.com/inject-config=true` annotation. This forms the basis of auto-injecting instrumentation agents into pods.