### PR TITLE
Update images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,15 @@ VERSION_COLLECTOR ?= "$(shell grep -v '\#' versions.txt | grep splunk-otel-colle
 LD_FLAGS ?= "-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.collectorVersion=${VERSION_COLLECTOR}"
 
 # Image URL to use all building/pushing image targets
-QUAY_USER ?= signalfx
-IMG_PREFIX ?= quay.io/${QUAY_USER}
-IMG_REPO ?= splunk-otel-operator
+# TODO: Once release pipelines are functional, remove this temporary redirect
+# back to quay.io from hub.docker.com/jvsplk/splunk-otel-collector-operator back
+# to quay.io/signalfx/splunk-otel-operator
+#QUAY_USER ?= signalfx
+#IMG_PREFIX ?= quay.io/${QUAY_USER}
+#IMG_REPO ?= splunk-otel-operator
+QUAY_USER ?= jvsplk
+IMG_PREFIX ?= ${QUAY_USER}
+IMG_REPO ?= splunk-otel-collector-operator
 IMG ?= ${IMG_PREFIX}/${IMG_REPO}:$(addprefix v,${VERSION})
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/apis/otel/v1alpha1/defaults.go
+++ b/apis/otel/v1alpha1/defaults.go
@@ -399,6 +399,6 @@ service:
 	defaultGatewayMemory = "8Gi"
 
 	// the javaagent version is managed by the update-javaagent-version.sh script.
-	defaultJavaAgentVersion = "v1.14.2"
+	defaultJavaAgentVersion = "v1.14.1"
 	defaultJavaAgentImage   = "quay.io/signalfx/splunk-otel-instrumentation-java:" + defaultJavaAgentVersion
 )

--- a/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
@@ -399,7 +399,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/signalfx/splunk-otel-operator:v0.0.4
+                image: jvsplk/splunk-otel-collector-operator:v0.0.4
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/signalfx/splunk-otel-operator
+  newName: jvsplk/splunk-otel-collector-operator
   newTag: v0.0.4


### PR DESCRIPTION
Redirecting two of the used images in this project due to issues in the Quay.io registry.

- splunk-otel-instrumentation-java is set to v1.14.1 because  v1.14.2 is missing.
- Redirecting usages of quay.io/signalfx/splunk-otel-operator:v0.0.4 to jvsplk/splunk-otel-collector-operator:v0.0.4 as a temporary work around due to quay.io upload issues preventing quay.io/signalfx/splunk-otel-operator:v0.0.4 from being created.