### PR TITLE
Add docs team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,14 @@
 #
 
 * @open-telemetry/collector-approvers @open-telemetry/operator-approvers
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md @signalfx/gdi-docs @open-telemetry/collector-approvers @open-telemetry/operator-approvers
+*.rst @signalfx/gdi-docs @open-telemetry/collector-approvers @open-telemetry/operator-approvers
+docs/ @signalfx/gdi-docs @open-telemetry/collector-approvers @open-telemetry/operator-approvers
+README* @signalfx/gdi-docs @open-telemetry/collector-approvers @open-telemetry/operator-approvers


### PR DESCRIPTION
Hi there! 

Following other repos of GDI that we document, I'm adding docs reviewers to the CODEOWNERS file.