### PR TITLE
Otel col v0.61.0 updates

### DIFF
--- a/apis/otel/v1alpha1/defaults.go
+++ b/apis/otel/v1alpha1/defaults.go
@@ -76,7 +76,6 @@ receivers:
     scrapers:
       cpu: null
       disk: null
-      filesystem: null
       load: null
       memory: null
       network: null
@@ -120,13 +119,33 @@ exporters:
   logging/debug:
     loglevel: debug
 processors:
-  k8s_tagger:
+  k8sattributes:
     extract:
-      metadata:
-        - k8s.namespace.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
+      annotations:
+      - from: pod
+        key: splunk.com/sourcetype
+      - from: namespace
+        key: splunk.com/exclude
+        tag_name: splunk.com/exclude
+      - from: pod
+        key: splunk.com/exclude
+        tag_name: splunk.com/exclude
+      - from: namespace
+        key: splunk.com/index
+        tag_name: com.splunk.index
+      - from: pod
+        key: splunk.com/index
+        tag_name: com.splunk.index
+    labels:
+      - key: app
+	metadata:
+      - k8s.namespace.name
+      - k8s.node.name
+      - k8s.pod.name
+      - k8s.pod.uid
+      - container.id
+      - container.image.name
+      - container.image.tag
     filter:
       node: '${MY_NODE_NAME}'
   batch: null
@@ -175,7 +194,7 @@ service:
         - jaeger
         - zipkin
       processors:
-        - k8s_tagger
+        - k8sattributes
         - batch
         - resource
         - resourcedetection

--- a/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
@@ -431,6 +431,8 @@ spec:
                     - ALL
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,6 +40,8 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/collector/serviceaccount_test.go
+++ b/internal/collector/serviceaccount_test.go
@@ -37,7 +37,7 @@ func TestServiceAccountNewDefault(t *testing.T) {
 	sa := ServiceAccountName(otelcol)
 
 	// verify
-	assert.Equal(t, "splunk-otel-operator-acccount", sa)
+	assert.Equal(t, "splunk-otel-operator-account", sa)
 }
 
 func TestServiceAccountOverride(t *testing.T) {

--- a/internal/naming/main.go
+++ b/internal/naming/main.go
@@ -72,7 +72,7 @@ func ServiceAccount(otelcol v1alpha1.Agent) string {
 	// TODO(splunk): create separate accounts for agent, clusterreceiver
 	// and gateway.
 	// return fmt.Sprintf("%s-account", otelcol.Name)
-	return "splunk-otel-operator-acccount"
+	return "splunk-otel-operator-account"
 }
 
 // Namespace builds the namespace name based on the instance.

--- a/tests/e2e/custom_all/01-assert.yaml
+++ b/tests/e2e/custom_all/01-assert.yaml
@@ -44,7 +44,6 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
@@ -88,13 +87,33 @@ data:
       logging/debug:
         loglevel: debug
     processors:
-      k8s_tagger:
+      k8sattributes:
         extract:
-          metadata:
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.name
-            - k8s.pod.uid
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+        labels:
+          - key: app
+        metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         filter:
           node: '${MY_NODE_NAME}'
       batch: null
@@ -143,7 +162,7 @@ data:
             - jaeger
             - zipkin
           processors:
-            - k8s_tagger
+            - k8sattributes
             - batch
             - resource
             - resourcedetection

--- a/tests/e2e/custom_all/01-install.yaml
+++ b/tests/e2e/custom_all/01-install.yaml
@@ -89,13 +89,33 @@ spec:
         logging/debug:
           loglevel: debug
       processors:
-        k8s_tagger:
+        k8sattributes:
           extract:
-            metadata:
-              - k8s.namespace.name
-              - k8s.node.name
-              - k8s.pod.name
-              - k8s.pod.uid
+            annotations:
+              - from: pod
+                key: splunk.com/sourcetype
+              - from: namespace
+                key: splunk.com/exclude
+                tag_name: splunk.com/exclude
+              - from: pod
+                key: splunk.com/exclude
+                tag_name: splunk.com/exclude
+              - from: namespace
+                key: splunk.com/index
+                tag_name: com.splunk.index
+              - from: pod
+                key: splunk.com/index
+                tag_name: com.splunk.index
+          labels:
+            - key: app
+        metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
           filter:
             node: '${MY_NODE_NAME}'
         batch: null

--- a/tests/e2e/gateway/01-assert.yaml
+++ b/tests/e2e/gateway/01-assert.yaml
@@ -283,7 +283,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: SPLUNK_MEMORY_TOTAL_MIB
               value: "200"
-          image: quay.io/signalfx/splunk-otel-collector:0.58.0
+          image: quay.io/signalfx/splunk-otel-collector:0.61.0
           imagePullPolicy: IfNotPresent
           name: otc-container
           resources:

--- a/tests/e2e/smoke-default/01-assert.yaml
+++ b/tests/e2e/smoke-default/01-assert.yaml
@@ -51,7 +51,6 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
@@ -95,13 +94,33 @@ data:
       logging/debug:
         loglevel: debug
     processors:
-      k8s_tagger:
+      k8sattributes:
         extract:
-          metadata:
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.name
-            - k8s.pod.uid
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+        labels:
+          - key: app
+        metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         filter:
           node: '${MY_NODE_NAME}'
       batch: null
@@ -150,7 +169,7 @@ data:
             - jaeger
             - zipkin
           processors:
-            - k8s_tagger
+            - k8sattributes
             - batch
             - resource
             - resourcedetection
@@ -472,7 +491,7 @@ spec:
               fieldPath: metadata.namespace
         - name: SPLUNK_MEMORY_TOTAL_MIB
           value: "500"
-        image: quay.io/signalfx/splunk-otel-collector:0.58.0
+        image: quay.io/signalfx/splunk-otel-collector:0.61.0
         imagePullPolicy: IfNotPresent
         name: otc-container
         resources:

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 # by default with the OpenTelemetry Operator. This would usually be the latest
 # stable OpenTelemetry version. When you update this file, make sure to update the
 # the docs as well.
-splunk-otel-collector=0.58.0
+splunk-otel-collector=0.61.0
 
 # Represents the current release of the OpenTelemetry Operator.
 operator=0.0.4


### PR DESCRIPTION
Updated the collector and related configurations. 
Due to current project limitations, the e2e tests won't pass until we create a new release for the operator. Please ignore the failing e2e tests for now.