### PR TITLE
Release v0.0.5

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
        kube-version:
-       - "1.22"
        - "1.23"
        - "1.24"
+       - "1.25"
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The Splunk OpenTelemetry Collector Operator *might* work on versions outside of 
 |------------|----------------------|
 | v0.0.3     | v1.20 to v1.23       |
 | v0.0.4     | v1.23 to v1.25       |
+| v0.0.5     | v1.23 to v1.25       |
 
 ## License
 

--- a/apis/otel/v1alpha1/defaults.go
+++ b/apis/otel/v1alpha1/defaults.go
@@ -136,9 +136,9 @@ processors:
       - from: pod
         key: splunk.com/index
         tag_name: com.splunk.index
-    labels:
+      labels:
       - key: app
-	metadata:
+      metadata:
       - k8s.namespace.name
       - k8s.node.name
       - k8s.pod.name

--- a/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/splunk-otel-collector-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: splunk-otel-collector-operator.v0.0.4
+  name: splunk-otel-collector-operator.v0.0.5
   namespace: splunk-otel-operator-system
 spec:
   apiservicedefinitions: {}
@@ -399,7 +399,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: jvsplk/splunk-otel-collector-operator:v0.0.4
+                image: jvsplk/splunk-otel-collector-operator:v0.0.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -506,7 +506,7 @@ spec:
   provider:
     name: Splunk Inc
     url: github.com/signalfx/splunk-otel-collector-operator
-  version: 0.0.4
+  version: 0.0.5
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: jvsplk/splunk-otel-collector-operator
-  newTag: v0.0.4
+  newTag: v0.0.5

--- a/kind-1.22.yaml
+++ b/kind-1.22.yaml
@@ -1,5 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-  image: kindest/node:v1.22.9@sha256:ad5b8404c4052781365a4e70bb7d17c5331e4177bd4a7cd214339316cd6193b6

--- a/kind-1.25.yaml
+++ b/kind-1.25.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace

--- a/tests/e2e/config-injection/01-install.yaml
+++ b/tests/e2e/config-injection/01-install.yaml
@@ -7,6 +7,13 @@ spec:
   realm: my-splunk-realm
   agent:
     enabled: true
+    resources:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        memory: 100Mi
+        cpu: 100m
   clusterReceiver:
     enabled: false
   gateway:

--- a/tests/e2e/custom_all/01-assert.yaml
+++ b/tests/e2e/custom_all/01-assert.yaml
@@ -104,9 +104,9 @@ data:
           - from: pod
             key: splunk.com/index
             tag_name: com.splunk.index
-        labels:
+          labels:
           - key: app
-        metadata:
+          metadata:
           - k8s.namespace.name
           - k8s.node.name
           - k8s.pod.name

--- a/tests/e2e/custom_all/01-install.yaml
+++ b/tests/e2e/custom_all/01-install.yaml
@@ -45,7 +45,6 @@ spec:
           scrapers:
             cpu: null
             disk: null
-            filesystem: null
             load: null
             memory: null
             network: null
@@ -92,30 +91,30 @@ spec:
         k8sattributes:
           extract:
             annotations:
-              - from: pod
-                key: splunk.com/sourcetype
-              - from: namespace
-                key: splunk.com/exclude
-                tag_name: splunk.com/exclude
-              - from: pod
-                key: splunk.com/exclude
-                tag_name: splunk.com/exclude
-              - from: namespace
-                key: splunk.com/index
-                tag_name: com.splunk.index
-              - from: pod
-                key: splunk.com/index
-                tag_name: com.splunk.index
-          labels:
+            - from: pod
+              key: splunk.com/sourcetype
+            - from: namespace
+              key: splunk.com/exclude
+              tag_name: splunk.com/exclude
+            - from: pod
+              key: splunk.com/exclude
+              tag_name: splunk.com/exclude
+            - from: namespace
+              key: splunk.com/index
+              tag_name: com.splunk.index
+            - from: pod
+              key: splunk.com/index
+              tag_name: com.splunk.index
+            labels:
             - key: app
-        metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
+            metadata:
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - container.id
+            - container.image.name
+            - container.image.tag
           filter:
             node: '${MY_NODE_NAME}'
         batch: null
@@ -164,7 +163,7 @@ spec:
               - jaeger
               - zipkin
             processors:
-              - k8s_tagger
+              - k8sattributes
               - batch
               - resource
               - resourcedetection

--- a/tests/e2e/smoke-default/01-assert.yaml
+++ b/tests/e2e/smoke-default/01-assert.yaml
@@ -111,9 +111,9 @@ data:
           - from: pod
             key: splunk.com/index
             tag_name: com.splunk.index
-        labels:
+          labels:
           - key: app
-        metadata:
+          metadata:
           - k8s.namespace.name
           - k8s.node.name
           - k8s.pod.name
@@ -490,17 +490,17 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         - name: SPLUNK_MEMORY_TOTAL_MIB
-          value: "500"
+          value: "200"
         image: quay.io/signalfx/splunk-otel-collector:0.61.0
         imagePullPolicy: IfNotPresent
         name: otc-container
         resources:
           limits:
             cpu: 200m
-            memory: 500Mi
+            memory: 200Mi
           requests:
-            cpu: 200m
-            memory: 500Mi
+            memory: 100Mi
+            cpu: 100m
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/tests/e2e/smoke-default/01-install.yaml
+++ b/tests/e2e/smoke-default/01-install.yaml
@@ -5,3 +5,11 @@ metadata:
 spec:
   clusterName: test-cluster
   realm: my-splunk-realm
+  agent:
+    resources:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        memory: 100Mi
+        cpu: 100m

--- a/versions.txt
+++ b/versions.txt
@@ -5,4 +5,4 @@
 splunk-otel-collector=0.61.0
 
 # Represents the current release of the OpenTelemetry Operator.
-operator=0.0.4
+operator=0.0.5


### PR DESCRIPTION
- Updated the e2e tests so they run successfully
- Updated the used Kubernetes versions to match the supported versions for the next release
- Create release v0.0.5
